### PR TITLE
Updated HasError for Bootstrap 4

### DIFF
--- a/src/components/HasError.vue
+++ b/src/components/HasError.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="help-block invalid-feedback" v-if="form.errors.has(field)" v-html="form.errors.get(field)"/>
+  <div class="form-text invalid-feedback" v-if="form.errors.has(field)" v-html="form.errors.get(field)"/>
 </template>
 
 <script>


### PR DESCRIPTION
Bootstrap 4 has dropped '.help-block' for '.form-text'. HasError had to be updated as it uses this class.
See https://getbootstrap.com/docs/4.0/migration/ .