### PR TITLE
Allow to pass axios config to the request helpers

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -89,50 +89,55 @@ class Form {
    * Submit the from via a GET request.
    *
    * @param  {String} url
+   * @param  {Object} config (axios config)
    * @return {Promise}
    */
-  get (url) {
-    return this.submit('get', url)
+  get (url, config = {}) {
+    return this.submit('get', url, config)
   }
 
   /**
    * Submit the from via a POST request.
    *
    * @param  {String} url
+   * @param  {Object} config (axios config)
    * @return {Promise}
    */
-  post (url) {
-    return this.submit('post', url)
+  post (url, config = {}) {
+    return this.submit('post', url, config)
   }
 
   /**
    * Submit the from via a PATCH request.
    *
    * @param  {String} url
+   * @param  {Object} config (axios config)
    * @return {Promise}
    */
-  patch (url) {
-    return this.submit('patch', url)
+  patch (url, config = {}) {
+    return this.submit('patch', url, config)
   }
 
   /**
    * Submit the from via a PUT request.
    *
    * @param  {String} url
+   * @param  {Object} config (axios config)
    * @return {Promise}
    */
-  put (url) {
-    return this.submit('put', url)
+  put (url, config = {}) {
+    return this.submit('put', url, config)
   }
 
   /**
    * Submit the from via a DELETE request.
    *
    * @param  {String} url
+   * @param  {Object} config (axios config)
    * @return {Promise}
    */
-  delete (url) {
-    return this.submit('delete', url)
+  delete (url, config = {}) {
+    return this.submit('delete', url, config)
   }
 
   /**

--- a/src/Form.js
+++ b/src/Form.js
@@ -86,7 +86,7 @@ class Form {
   }
 
   /**
-   * Submit the from via a GET request.
+   * Submit the form via a GET request.
    *
    * @param  {String} url
    * @param  {Object} config (axios config)
@@ -97,7 +97,7 @@ class Form {
   }
 
   /**
-   * Submit the from via a POST request.
+   * Submit the form via a POST request.
    *
    * @param  {String} url
    * @param  {Object} config (axios config)
@@ -108,7 +108,7 @@ class Form {
   }
 
   /**
-   * Submit the from via a PATCH request.
+   * Submit the form via a PATCH request.
    *
    * @param  {String} url
    * @param  {Object} config (axios config)
@@ -119,7 +119,7 @@ class Form {
   }
 
   /**
-   * Submit the from via a PUT request.
+   * Submit the form via a PUT request.
    *
    * @param  {String} url
    * @param  {Object} config (axios config)
@@ -130,7 +130,7 @@ class Form {
   }
 
   /**
-   * Submit the from via a DELETE request.
+   * Submit the form via a DELETE request.
    *
    * @param  {String} url
    * @param  {Object} config (axios config)


### PR DESCRIPTION
+ With this PR you can add the axios config object to every request helpers, example:
```
this.form.put('my-url', { params: { ... } })
```
Instead of need to use directly the submit method when you need to add config like `parameters`:
```
this.form.submit('put', 'my-url'', { params: {...} })
```
+ Fixed a typo in the docblock