### PR TITLE
Set the "params" property for GET requests. Set the "data" property f…

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -151,12 +151,14 @@ class Form {
   submit (method, url, config = {}) {
     this.startProcessing()
 
-    const data = method === 'get'
-      ? { params: this.data() }
-      : this.data()
+    if (method === 'get') {
+      config.params = this.data()
+    } else {
+      config.data = this.data()
+    }
 
     return new Promise((resolve, reject) => {
-      axios.request({ url: this.route(url), method, data, ...config })
+      axios.request({ url: this.route(url), method, ...config })
         .then(response => {
           this.finishProcessing()
 


### PR DESCRIPTION
When performing a GET request, the submit method was trying to set the *data* property to `{params: this.data()}`, but axios expects a GET request to have a separate `params` property, so this change will properly set the `params` property for GET requests, and the `data` property for all other method types.