### PR TITLE
Allows to pass a fully qualified url

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -154,9 +154,13 @@ class Form {
     const data = method === 'get'
       ? { params: this.data() }
       : this.data()
+    
+    if (!url.startsWith('http')) {
+      url = this.route(url)
+    }
 
     return new Promise((resolve, reject) => {
-      (Form.axios || axios).request({ url: this.route(url), method, data, ...config })
+      (Form.axios || axios).request({ url, method, data, ...config })
         .then(response => {
           this.finishProcessing()
 


### PR DESCRIPTION
Hi @cretueusebiu !
This package is really good, and I hope it won't be abandoned (issue not merged/closed since 2 years  =( )!

I used it as default with your other package about Laravel-Nuxt boilerplate, the problem is I love to use tighten/ziggy to generate my Laravel's routes to use them inside my front app and in my case, the API is located under a subdomain, so I couldn't work directly with a basic uri `/login` and needed to pass a fully qualified url like `http://api.myapp.com/login`

I tried to work without the need to make a PR:
- I saw that I could pass an axios config to the Form so I tried to add a `baseURL` > it didn't work
- I saw that I can register the routes as a property of the form > it didn't work neither

Maybe it exists a way, maybe I used it the wrong way, but it should not be that difficult to just call a fully qualified URL so I feel like this PR is needed.