### PR TITLE
Like Inertia feature: recentlySuccessful 

### DIFF
--- a/src/Form.ts
+++ b/src/Form.ts
@@ -46,7 +46,7 @@ class Form {
   static axios: AxiosInstance
   static routes: Record<string, string> = {}
   static errorMessage = 'Something went wrong. Please try again.'
-  static ignore = ['busy', 'successful', 'errors', 'progress', 'originalData']
+  static ignore = ['busy', 'successful', 'errors', 'progress', 'originalData', 'recentlySuccessfulTimeoutId', 'recentlySuccessful']
 
   /**
    * Create a new form instance.

--- a/src/Form.ts
+++ b/src/Form.ts
@@ -18,20 +18,16 @@ class Form {
    */
   busy: boolean = false
 
-  recentlySuccessfulTimeoutId: number | undefined = undefined;
-
-  /**
-   * When a form has been successfully submitted, the successful property will be true.
-   * In addition to this, there is also a recentlySuccessful property,
-   * which will be set to true for two seconds after a successful form submission.
-   * This is helpful for showing temporary success messages.
-   */
-  recentlySuccessful: boolean = false;
-
   /**
    * Indicates if the response form the server was successful.
    */
   successful: boolean = false
+
+  /**
+   * Indicates if the response form the server was recently successful.
+   */
+  recentlySuccessful: boolean = false
+  recentlySuccessfulTimeoutId: number | undefined = undefined
 
   /**
    * The validation errors from the server.
@@ -46,7 +42,8 @@ class Form {
   static axios: AxiosInstance
   static routes: Record<string, string> = {}
   static errorMessage = 'Something went wrong. Please try again.'
-  static ignore = ['busy', 'successful', 'errors', 'progress', 'originalData', 'recentlySuccessfulTimeoutId', 'recentlySuccessful']
+  static recentlySuccessfulTimeout = 2000
+  static ignore = ['busy', 'successful', 'errors', 'progress', 'originalData', 'recentlySuccessful', 'recentlySuccessfulTimeoutId']
 
   /**
    * Create a new form instance.
@@ -116,7 +113,9 @@ class Form {
     this.successful = true
     this.progress = undefined
     this.recentlySuccessful = true
-    this.recentlySuccessfulTimeoutId = setTimeout(() => this.recentlySuccessful = false, 2000)
+    this.recentlySuccessfulTimeoutId = setTimeout(() => {
+      this.recentlySuccessful = false
+    }, Form.recentlySuccessfulTimeout)
   }
 
   /**
@@ -125,7 +124,9 @@ class Form {
   clear () {
     this.errors.clear()
     this.successful = false
+    this.recentlySuccessful = false
     this.progress = undefined
+    clearTimeout(this.recentlySuccessfulTimeoutId)
   }
 
   /**

--- a/src/Form.ts
+++ b/src/Form.ts
@@ -18,6 +18,16 @@ class Form {
    */
   busy: boolean = false
 
+  recentlySuccessfulTimeoutId: number | undefined = undefined;
+
+  /**
+   * When a form has been successfully submitted, the successful property will be true.
+   * In addition to this, there is also a recentlySuccessful property,
+   * which will be set to true for two seconds after a successful form submission.
+   * This is helpful for showing temporary success messages.
+   */
+  recentlySuccessful: boolean = false;
+
   /**
    * Indicates if the response form the server was successful.
    */
@@ -94,6 +104,8 @@ class Form {
     this.busy = true
     this.successful = false
     this.progress = undefined
+    this.recentlySuccessful = false
+    clearTimeout(this.recentlySuccessfulTimeoutId)
   }
 
   /**
@@ -103,6 +115,8 @@ class Form {
     this.busy = false
     this.successful = true
     this.progress = undefined
+    this.recentlySuccessful = true
+    this.recentlySuccessfulTimeoutId = setTimeout(() => this.recentlySuccessful = false, 2000)
   }
 
   /**

--- a/test/Form.test.ts
+++ b/test/Form.test.ts
@@ -7,6 +7,8 @@ let form: Form
 let mockAdapter: MockAdapter
 
 beforeEach(() => {
+  Form.recentlySuccessfulTimeout = 100
+
   form = Form.make({
     username: 'foo',
     password: 'bar'
@@ -20,6 +22,7 @@ describe('Form', () => {
     expect(form.busy).toBeFalsy()
     expect(form.successful).toBeFalsy()
     expect(form.successful).toBeFalsy()
+    expect(form.recentlySuccessful).toBeFalsy()
     expect(form.errors).toBeInstanceOf(Errors)
     expect(form.originalData).toEqual({ username: 'foo', password: 'bar' })
   })
@@ -52,6 +55,7 @@ describe('Form', () => {
 
     expect(form.busy).toBeTruthy()
     expect(form.successful).toBeFalsy()
+    expect(form.recentlySuccessful).toBeFalsy()
     expect(form.errors.any()).toBeFalsy()
   })
 
@@ -60,13 +64,18 @@ describe('Form', () => {
 
     expect(form.busy).toBeFalsy()
     expect(form.successful).toBeTruthy()
+    expect(form.recentlySuccessful).toBeTruthy()
   })
 
   test('clear the form errors', () => {
+    form.successful = true
+    form.recentlySuccessful = true
+
     form.clear()
 
     expect(form.errors.any()).toBeFalsy()
     expect(form.successful).toBeFalsy()
+    expect(form.recentlySuccessful).toBeFalsy()
   })
 
   test('reset the form values', () => {
@@ -87,7 +96,12 @@ describe('Form', () => {
 
     expect(form.busy).toBeFalsy()
     expect(form.successful).toBeTruthy()
+    expect(form.recentlySuccessful).toBeTruthy()
     expect(form.errors.any()).toBeFalsy()
+
+    await new Promise(resolve => setTimeout(resolve, 101))
+
+    expect(form.recentlySuccessful).toBeFalsy()
   })
 
   test('transform data object to FormData', async () => {
@@ -120,6 +134,7 @@ describe('Form', () => {
     expect(form.errors.any()).toBeTruthy()
     expect(form.busy).toBeFalsy()
     expect(form.successful).toBeFalsy()
+    expect(form.recentlySuccessful).toBeFalsy()
   })
 
   test('make get request', async () => {


### PR DESCRIPTION
When a form has been successfully submitted, the successful property will be true. In addition to this, there is also a recentlySuccessful property, which will be set to true for two seconds after a successful form submission. This is helpful for showing temporary success messages.