### PR TITLE
Always include message in errors object

### DIFF
--- a/src/Form.ts
+++ b/src/Form.ts
@@ -234,7 +234,7 @@ class Form {
     }
 
     if (response.data.errors) {
-      return { ...response.data.errors }
+      return { ...response.data.errors, error: response.data.message }
     }
 
     if (response.data.message) {


### PR DESCRIPTION
With Laravels new improved validation messages ("The name field is required. (and 1 more error)") it's a nice feature to always have the returned message available for use in AlertError and custom components from the Error array.